### PR TITLE
Fix postinstall script on Windows

### DIFF
--- a/ensure-no-npm.js
+++ b/ensure-no-npm.js
@@ -1,0 +1,5 @@
+const fs = require("fs")
+
+if (fs.existsSync("package-lock.json")) {
+  console.log("\u001b[41mVaxxnz uses Yarn and not NPM. Don't commit package-lock.json\u001b[0m");
+}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "prepare": "husky install",
-    "postinstall": "test -f package-lock.json && echo \"$(tput setab 1)Vaxxnz uses Yarn and not NPM. Don't commit package-lock.json$(tput sgr0)\" || true"
+    "postinstall": "node ensure-no-npm.js"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Proposed Changes
Fix post-install script on Windows. Behaviour on unix environment is kept the same.

Closes #263 

## Additional Info.

Note that if you use WSL on Windows for this project previously, and want to convert back to Powershell or CMD because now the script now has been fixed, you need to delete `node_modules` first and rerun `yarn install` from Powershell / CMD.

## Screenshots (optional)
