### PR TITLE
Add Intl.NumberFormat fallback for Safari 14

### DIFF
--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -68,9 +68,9 @@ export function formatDistanceKm(km: number, language: string): string {
     }
   } catch (e) {
     if (km < 1) {
-      return `${km * 1000} m`;
+      return `${(km * 1000).toFixed(0)} m`;
     } else {
-      return `${km} km`;
+      return `${km.toFixed(1)} km`;
     }
   }
 }


### PR DESCRIPTION
## Proposed Changes
1. Attempt to fix #317 

## Additional Info.
Safari 14 doesn't understand `style: "unit"`. Try-catch the invocation and fallback to hand crafted string.

Safari 15 works fine.

I don't have Safari 14 to test.
