### PR TITLE
fix: replaced links to reference vaxxnz instead of CovidEngine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for agreeing to help contribute to the Vaxx Website!
 
-By contributing, you agree to the [code of conduct here](https://github.com/CovidEngine/vaxxnz/blob/main/CODE_OF_CONDUCT.md)
+By contributing, you agree to the [code of conduct here](https://github.com/vaxxnz/vaxxnz/blob/main/CODE_OF_CONDUCT.md)
 
 Here are some ways to help:
 
@@ -12,18 +12,18 @@ Here are some ways to help:
 
 - Once you've joined the Discord, introduce yourself, and let the channel know you would like to contribute in #introductions 🥳
 
-- Have a look at some [open issues](https://github.com/CovidEngine/vaxxnz/issues) and see if anyone needs any help investigating a problem or bug
+- Have a look at some [open issues](https://github.com/vaxxnz/vaxxnz/issues) and see if anyone needs any help investigating a problem or bug
 
-- [Review our roadmap ](https://github.com/CovidEngine/vaxxnz/projects/2) and join the discussion
+- [Review our roadmap ](https://github.com/vaxxnz/vaxxnz/projects/2) and join the discussion
 
 - Help us translate the page if you speak another language!
 
-- Propose a new idea or feature by [Creating an issue](https://github.com/CovidEngine/vaxxnz/issues)
+- Propose a new idea or feature by [Creating an issue](https://github.com/vaxxnz/vaxxnz/issues)
 
 ## For Designers:
 
 - We have a [figma file here](https://www.figma.com/file/4oWThzqdwnGO0ibpbWR3zd/Vaxxtastic?node-id=0%3A1)
-- We'll set up a research repository soon at https://github.com/CovidEngine/vaxxnz/wiki
+- We'll set up a research repository soon at https://github.com/vaxxnz/vaxxnz/wiki
 
 ## For Developers:
 

--- a/CONTRIBUTING_DEV.md
+++ b/CONTRIBUTING_DEV.md
@@ -47,13 +47,13 @@ Make sure you have these tools installed locally:
 
 ### Task 5. Start development
 
-- Have a look at [good first issues](https://github.com/CovidEngine/vaxxnz/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). It's a list of issues which are more straight forward than other ones and easier to get started with.
+- Have a look at [good first issues](https://github.com/vaxxnz/vaxxnz/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). It's a list of issues which are more straight forward than other ones and easier to get started with.
 
-- Have a look at other [open issues](https://github.com/CovidEngine/vaxxnz/issues) and see if anyone needs any help investigating a problem or bug
+- Have a look at other [open issues](https://github.com/vaxxnz/vaxxnz/issues) and see if anyone needs any help investigating a problem or bug
 
-- [Review our roadmap ](https://github.com/CovidEngine/vaxxnz/projects/2) and join the discussion
+- [Review our roadmap ](https://github.com/vaxxnz/vaxxnz/projects/2) and join the discussion
 
-- Propose a new idea or feature by [Creating an issue](https://github.com/CovidEngine/vaxxnz/issues)
+- Propose a new idea or feature by [Creating an issue](https://github.com/vaxxnz/vaxxnz/issues)
 
 ### Task 6. Start development
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In response to this, we've built [vaxx.nz](https://vaxx.nz) to make the experien
 
 ### Built by:
 
-![Contributors](https://contrib.rocks/image?repo=CovidEngine/vaxxnz)
+![Contributors](https://contrib.rocks/image?repo=vaxxnz/vaxxnz)
 
 ## How does it work?
 
@@ -47,5 +47,5 @@ Following our launch, we welcomed an average of 2,800 users every 30 minutes! Al
 
 ## Resources
 
-- Periodically updated JSON of all available slots: [see raw data here](https://github.com/CovidEngine/vaxxnzlocations)
+- Periodically updated JSON of all available slots: [see raw data here](https://github.com/vaxxnz/vaxxnzlocations)
 - Vaxx.nz Widget: [see here](https://docs.vaxx.nz)

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -37,7 +37,7 @@ export function Footer() {
           </a>{" "}
           /{" "}
           <a
-            href="https://github.com/CovidEngine/vaxxnz/projects/2"
+            href="https://github.com/vaxxnz/vaxxnz/projects/2"
             target="_blank"
             rel="noreferrer"
             onClick={() => enqueueAnalyticsEvent("Roadmap clicked")}
@@ -46,7 +46,7 @@ export function Footer() {
           </a>{" "}
           /{" "}
           <a
-            href="https://github.com/CovidEngine/vaxxnz/blob/main/CONTRIBUTING.md"
+            href="https://github.com/vaxxnz/vaxxnz/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noreferrer"
           >
@@ -54,7 +54,7 @@ export function Footer() {
           </a>
           <br />{" "}
           <a
-            href="https://github.com/CovidEngine/vaxxnzlocations"
+            href="https://github.com/vaxxnz/vaxxnzlocations"
             target="_blank"
             rel="noreferrer"
             onClick={() => enqueueAnalyticsEvent("Raw data clicked")}
@@ -63,7 +63,7 @@ export function Footer() {
           </a>{" "}
           /{" "}
           <a
-            href="https://github.com/CovidEngine/vaxxnz"
+            href="https://github.com/vaxxnz/vaxxnz"
             target="_blank"
             rel="noreferrer"
             onClick={() => enqueueAnalyticsEvent("Source code clicked")}

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -12,7 +12,7 @@ export function Header() {
       <div className="menu-divider">
         {" "}
         <a
-          href="https://github.com/CovidEngine/vaxxnz"
+          href="https://github.com/vaxxnz/vaxxnz"
           target="_blank"
           rel="noreferrer"
           className="menu-link"

--- a/src/calendar/CalendarError.tsx
+++ b/src/calendar/CalendarError.tsx
@@ -120,7 +120,7 @@ export function CalendarError(props: { errorMessage: string }) {
           <Section>
             <Subheader>{t("core.mistake")}</Subheader>
             <Button
-              href="https://github.com/CovidEngine/vaxxnz/issues"
+              href="https://github.com/vaxxnz/vaxxnz/issues"
               target="_blank"
             >
               Report Error

--- a/src/calendar/booking/BookingData.ts
+++ b/src/calendar/booking/BookingData.ts
@@ -22,7 +22,7 @@ import {
 
 const getLocations = memoizeOnce(async function () {
   const res = await fetch(
-    "https://raw.githubusercontent.com/CovidEngine/vaxxnzlocations/main/uniqLocations.json"
+    "https://raw.githubusercontent.com/vaxxnz/vaxxnzlocations/main/uniqLocations.json"
   );
   const dataRaw: LocationRaw[] = await res.json();
   const data: Location[] = dataRaw.map((l) => ({
@@ -36,7 +36,7 @@ const getLocations = memoizeOnce(async function () {
 
 const getAvailabilityData = memoize0(async function (extId: string) {
   const res = await fetch(
-    `https://raw.githubusercontent.com/CovidEngine/vaxxnzlocations/main/availability/${extId}.json`
+    `https://raw.githubusercontent.com/vaxxnz/vaxxnzlocations/main/availability/${extId}.json`
   );
   const data: AvailabilityData = await res.json();
   return data;

--- a/src/faq.tsx
+++ b/src/faq.tsx
@@ -27,16 +27,16 @@ const faq = () => {
           <h4>Who maintains Vaxx.nz?</h4>
           <p>
             Vaxx.nz is an open source community project run by volunteers:{" "}
-            <a href="https://github.com/CovidEngine/vaxxnz#built-by">
-              https://github.com/CovidEngine/vaxxnz#built-by
+            <a href="https://github.com/vaxxnz/vaxxnz#built-by">
+              https://github.com/vaxxnz/vaxxnz#built-by
             </a>
           </p>
           <br />
           <h4>How do I get involved?</h4>
           <p>
             Head over to{" "}
-            <a href="https://github.com/CovidEngine/vaxxnz/blob/main/CONTRIBUTING.md">
-              https://github.com/CovidEngine/vaxxnz/blob/main/CONTRIBUTING.md
+            <a href="https://github.com/vaxxnz/vaxxnz/blob/main/CONTRIBUTING.md">
+              https://github.com/vaxxnz/vaxxnz/blob/main/CONTRIBUTING.md
             </a>
           </p>
           <br />

--- a/src/today-locations/healthpoint/HealthpointData.ts
+++ b/src/today-locations/healthpoint/HealthpointData.ts
@@ -39,7 +39,7 @@ export interface HealthpointLocation extends HealthpointLocationRaw {
 export const getHealthpointData = memoizeOnce(
   async (): Promise<HealthpointLocation[]> => {
     const r = await fetch(
-      "https://raw.githubusercontent.com/CovidEngine/vaxxnzlocations/main/healthpointLocations.json"
+      "https://raw.githubusercontent.com/vaxxnz/vaxxnzlocations/main/healthpointLocations.json"
     );
     const locs = await r.json();
     return locs.map((l: HealthpointLocationRaw) => ({

--- a/src/translations/scripts/uniqCrowdsourced.ts
+++ b/src/translations/scripts/uniqCrowdsourced.ts
@@ -12,7 +12,7 @@ async function main() {
   let healthpointLocations: HealthpointLocation[] = [];
   https
     .get(
-      "https://raw.githubusercontent.com/CovidEngine/vaxxnzlocations/main/healthpointLocations.json",
+      "https://raw.githubusercontent.com/vaxxnz/vaxxnzlocations/main/healthpointLocations.json",
       (resp) => {
         let data = "";
         resp.on("data", (chunk) => {


### PR DESCRIPTION
## Proposed Changes
1.  Replaced links that reference CovidEngine to reference vaxxnz instead

fixes #326 